### PR TITLE
Change enumerabe to enumerable

### DIFF
--- a/data/inject.js
+++ b/data/inject.js
@@ -28,7 +28,7 @@
 				askFunctionName,
 				{
 					value: getContext,
-					enumerabe: false
+					enumerable: false
 				}
 			);
 			unsafeWindow.HTMLCanvasElement.prototype.getContext = new unsafeWindow.Function(
@@ -66,7 +66,7 @@
 				askFunctionName,
 				{
 					value: getContext,
-					enumerabe: false
+					enumerable: false
 				}
 			);
 			unsafeWindow.HTMLCanvasElement.prototype.getContext = new unsafeWindow.Function(


### PR DESCRIPTION
The default is false, so the typo had no impact.
https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/defineProperty
