### PR TITLE
Show caller when asking for readout permission

### DIFF
--- a/data/inject.js
+++ b/data/inject.js
@@ -101,10 +101,27 @@
 							status = askStatus.answer;
 						}
 						else {
-							// console.log("asking");
-							status = window.confirm(_(changedFunction.mode.askText))? "allow": "block";
+							//unsafeWindow.console.log("asking");
+							var callers = new Error().stack.split('\n');
+							var findme = callers.shift(); // Remove us from the stack
+							findme = findme.replace(/(:[0-9]+){1,2}$/, ""); // rm line & column
+							// Eliminate squashed stack. stack may contain 2+ stacks, but why...
+							for (var i = 0; callers[i]; i++){
+								if (callers[i].search(findme) == 0){
+									callers.splice(i, callers.length - i);
+									break;
+								}
+							}
+							var msg = _(changedFunction.mode.askText);
+							if (changedFunction.mode.askText === "askForReadoutPermission"){
+								msg += "\n\nCaller: " + callers[0];
+								// maybe show full stack here if some pref
+								//msg += "\n\nFull stack: \n" + callers.join('\n');
+							}
+							status = window.confirm(msg) ? "allow": "block";
 							askStatus.alreadyAsked = true;
 							askStatus.answer = status;
+							//unsafeWindow.console.log("asking (done)");
 						}
 					}
 					switch (status){


### PR DESCRIPTION
Get stack and show the caller when asking for readout API permission.

Related to enhancement request to show source where canvas is nested.
https://github.com/kkapsner/CanvasBlocker/issues/8

![clipboard01](https://cloud.githubusercontent.com/assets/965580/5329928/16f172b0-7d99-11e4-80b7-541095a2197b.png)
![clipboard02](https://cloud.githubusercontent.com/assets/965580/5329929/1ad419fa-7d99-11e4-9751-39845c6e6f8f.png)
