### PR TITLE
Options: Using by default json as prefered file type for loading settings

### DIFF
--- a/options/options.js
+++ b/options/options.js
@@ -96,6 +96,7 @@
 			const text = await new Promise(function(resolve, reject){
 				const input = document.createElement("input");
 				input.type = "file";
+				input.accept = "application/json";
 				input.addEventListener("change", function(){
 					if (this.files.length){
 						const reader = new FileReader();


### PR DESCRIPTION
Settings are exported by default as ``.json`` file, so let's import them by default as ``json`` file 😸 

Looks now like this:
![grafik](https://user-images.githubusercontent.com/40789489/95674630-c0ff3600-0bb1-11eb-9416-a97394a86dfa.png)
