### PR TITLE
Replace deprecated String.prototype.substr()

### DIFF
--- a/.tools/build.js
+++ b/.tools/build.js
@@ -17,7 +17,7 @@ const fs = require("fs");
 function getAlphaVersion(manifest){
 	"use strict";
 	const now = new Date();
-	const date = now.toISOString().substr(0, 10).replace(/-/g, "");
+	const date = now.toISOString().substring(0, 10).replace(/-/g, "");
 	return manifest.version.replace(/^([\d.]+).*$/, "$1Alpha" + date);
 }
 function getRCVersion(manifest){

--- a/.tools/buildChromeVendors.js
+++ b/.tools/buildChromeVendors.js
@@ -126,10 +126,10 @@ const decompressed2 = decompress(compressed2, usedWords);
 console.log("test: ", compressed === decompressed2);
 for (let start = 0; start < compressed.length; start += 100){
 	
-	if (compressed.substr(start, 100) !== decompressed2.substr(start, 100)){
+	if (compressed.substring(start, start + 100) !== decompressed2.substring(start, start + 100)){
 		console.log(start);
-		console.log(compressed.substr(start, 100));
-		console.log(decompressed2.substr(start, 100));
+		console.log(compressed.substring(start, start + 100));
+		console.log(decompressed2.substring(start, start + 100));
 	}
 }
 

--- a/test/iframeTest.js
+++ b/test/iframeTest.js
@@ -6,7 +6,7 @@ var log = function(){
 			str.unshift("color: green");
 			str.unshift("%cOK");
 		}
-		else if (str[str.length - 1].substr(0, 9) === "missmatch"){
+		else if (str[str.length - 1].startsWith("missmatch")){
 			str.unshift("color: red");
 			str.unshift("%cX");
 		}


### PR DESCRIPTION
[String.prototype.substr()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substr) is deprecated so we replace it with [String.prototype.slice()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/slice) which works similarily but isn't deprecated.
.substr() probably isn't going away anytime soon but the change is trivial so it doesn't hurt to do it.